### PR TITLE
fix GitHub languages show

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Quali-Shells-Open-Source.rtf linguist-documentation


### PR DESCRIPTION
Do not count Quali-Shells-Open-Source.rtf in GitHub language details
![image](https://user-images.githubusercontent.com/12509502/81838210-7e77f580-954e-11ea-881d-99927fcaea88.png)
