### PR TITLE
Revert "fix setuptools breaks python2.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools<45
 jsonpickle
 cloudshell-automation-api
 cloudshell-logging>=1.0,<2


### PR DESCRIPTION
Reverts QualiSystems/cloudshell-shell-core#86

there is no need for it if we have pip>=9